### PR TITLE
Update package name to `generic-rest-api-dev` and version to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.4] - 2025-06-27
+
+### Changed
+- 📦 **Package Name**: Updated package name to `generic-rest-api-dev` throughout documentation
+- 📖 **Documentation**: Updated README.md and USAGE.md to reflect new package name
+- 🔧 **Installation Commands**: Updated all npm install examples to use `generic-rest-api-dev`
+- 💻 **Code Examples**: Updated all require statements to use `generic-rest-api-dev`
+
 ## [1.0.0] - 2025-06-27
 
 ### Added - Library Transformation
 - 🚀 **CLI Command**: Global installable command `generic-rest`
-- 📦 **NPM Package**: Can be installed via `npm install generic-rest-api`
+- 📦 **NPM Package**: Can be installed via `npm install generic-rest-api-dev`
 - 🔧 **Programmatic API**: `GenericRestServer` class for embedding in Node.js apps
 - 📖 **Package.json Scripts**: Easy integration with project scripts
 - 🛠 **Command Line Options**: `--port`, `--db-path`, `--help`
 - 📝 **Usage Documentation**: Comprehensive USAGE.md with examples
-- ⚡ **NPX Support**: Run without installation using `npx generic-rest-api`
+- ⚡ **NPX Support**: Run without installation using `npx generic-rest-api-dev`
 
 ### Changed - Code Structure
 - 🏗 **Refactored Architecture**: Split monolithic file into modular structure
@@ -34,13 +42,13 @@ All notable changes to this project will be documented in this file.
 ### Installation Options
 ```bash
 # Global installation
-npm install -g generic-rest-api
+npm install -g generic-rest-api-dev
 
 # Project dependency
-npm install generic-rest-api
+npm install generic-rest-api-dev
 
 # No installation (npx)
-npx generic-rest-api
+npx generic-rest-api-dev
 ```
 
 ### Usage Examples
@@ -57,7 +65,7 @@ generic-rest --port 8080 --db-path ./data
 }
 
 # Programmatic usage
-const { GenericRestServer } = require('generic-rest-api');
+const { GenericRestServer } = require('generic-rest-api-dev');
 const server = new GenericRestServer({ port: 3000, dbPath: './data' });
 server.start();
 ```

--- a/README.md
+++ b/README.md
@@ -454,8 +454,8 @@ To publish this package to npm:
 
 ```bash
 # Clone repository
-git clone https://github.com/your-username/generic-rest-api.git
-cd generic-rest-api
+git clone https://github.com/your-username/generic-rest-api-dev.git
+cd generic-rest-api-dev
 
 # Install dependencies
 npm install

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,12 +4,12 @@
 
 ### Install globally
 ```bash
-npm install -g generic-rest-api
+npm install -g generic-rest-api-dev
 ```
 
 ### Install as project dependency
 ```bash
-npm install generic-rest-api
+npm install generic-rest-api-dev
 ```
 
 ## Command Line Usage
@@ -31,8 +31,8 @@ generic-rest -p 8080 --db ./api-data
 
 ### Using npx (no installation needed)
 ```bash
-npx generic-rest-api
-npx generic-rest-api --port 8080 --db-path ./data
+npx generic-rest-api-dev
+npx generic-rest-api-dev --port 8080 --db-path ./data
 ```
 
 ## Package.json Scripts
@@ -61,7 +61,7 @@ npm run backend      # Starts on port 4000 with ./backend-data
 
 ### Basic server setup
 ```javascript
-const { GenericRestServer } = require('generic-rest-api');
+const { GenericRestServer } = require('generic-rest-api-dev');
 
 const server = new GenericRestServer({
   port: 3000,
@@ -75,7 +75,7 @@ server.start().then(() => {
 
 ### With custom middleware
 ```javascript
-const { GenericRestServer } = require('generic-rest-api');
+const { GenericRestServer } = require('generic-rest-api-dev');
 
 const server = new GenericRestServer({
   port: process.env.PORT || 4000,
@@ -111,7 +111,7 @@ server.start().catch(console.error);
 
 ### With graceful shutdown
 ```javascript
-const { GenericRestServer } = require('generic-rest-api');
+const { GenericRestServer } = require('generic-rest-api-dev');
 
 const server = new GenericRestServer({
   port: 3000,
@@ -257,7 +257,7 @@ services:
       - .:/app
     ports:
       - "3000:3000"
-    command: npx generic-rest-api --port 3000 --db-path /app/data
+    command: npx generic-rest-api-dev --port 3000 --db-path /app/data
     
   frontend:
     image: node:16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-rest-api-dev",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A generic REST API library that creates and manages JSON files based on the request path. Perfect for rapid prototyping, testing, and development environments.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Revise documentation and usage examples to reflect the new package name and version. Update installation commands and code examples accordingly.